### PR TITLE
run tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,5 +18,5 @@ count="$(echo "$scripts" | wc -l | tr -d ' ')"
 echo "tests/ - $count public scripts"
 [[ -n "$scripts" ]] && while IFS= read f; do
     ( set -x; chmod +x "$f" ) || exit
-    ( set -x; "$@" ) || exit
+    ( set -x; "$f" ) || exit
 done <<< "$scripts";:

--- a/run.sh
+++ b/run.sh
@@ -18,5 +18,5 @@ count="$(echo "$scripts" | wc -l | tr -d ' ')"
 echo "tests/ - $count public scripts"
 [[ -n "$scripts" ]] && while IFS= read f; do
     ( set -x; chmod +x "$f" ) || exit
-    ( set -x; "$@" ) || exit
+    ( set -x; "$f" ) || exit
 done <<< "$scripts";:


### PR DESCRIPTION
In the process of [fixing a minor issue with env-file.py](https://github.com/andrewp-as-is/env-file.py/pull/1), I committed an intentionally failing test. However, [travis-ci tests still passed](https://travis-ci.org/github/tomviner/env-file.py/builds/685019817). I could reproduce this locally.

It appeared the tests were not actually being run, at least for the version of bash myself (`GNU bash, version 4.4.20(1)-release (x86_64-pc-linux-gnu)`) and travis-ci (`GNU bash, version 4.3.48(1)-release (x86_64-pc-linux-gnu)`) are using.

I found there was a further change to make `run-tests` work correctly, which was to install the requirements first. This might suggest a docs fix for this repo, which I'll put in [another PR](https://github.com/run-tests/run-tests.github.com/pull/2).

Once that was done, the tests correctly failed, and indeed passed, when I committed the fix I had in mind.

You can see the [test sequence here](https://travis-ci.org/github/tomviner/env-file.py/builds).